### PR TITLE
Unify Zip and Image lambda deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,39 @@
 
 [![Test](https://github.com/mergermarket/terraform-acuris-aws-lambda/actions/workflows/test.yml/badge.svg)](https://github.com/mergermarket/terraform-acuris-aws-lambda/actions/workflows/test.yml)
 
-This module will deploy a Lambda function.
+This module will deploy a Lambda function. It supports both Zip and Image deployments.
 
-## Module Input Variables
+> NOTE 1: if image_uri is set then ECR Image will be deployed regardless of what Zip deployment properties are set to.
+
+> NOTE 2: if both security_group_ids and subnet_ids are empty then the Lambda will not have access to resources within a VPC.
+
+## Module input variables (shared)
 
 - `function_name` - (string) - **REQUIRED** - The name of the Lambda function.
-- `handler` - (map) - **REQUIRED (Zip deployment)** - The function within your code that Lambda calls to begin execution.
 - `lambda_env` - (map) - Environment parameters passed to the Lambda function.
 - `lambda_role_policy` (string) - The Lambda IAM Role Policy.
 - `log_subscription_filter` - (string) - Subscription filter to filter logs sent to datadog.
 - `memory_size` (number) - Amount of memory in MB your Lambda Function can use at runtime.
-- `runtime` - (string) - **REQUIRED (Zip deployment)** - The runtime environment for the Lambda function you are uploading.
-- `s3_bucket` - (string) - **REQUIRED  (Zip deployment)** - The name of the bucket containing your uploaded Lambda deployment package.
-- `s3_key` - (string) - **REQUIRED (Zip deployment)** - The s3 key for your Lambda deployment package.
-- `image_uri` - (string) - **REQUIRED (Image deployment)** - Uri to the image in ECR repo.
-- `image_config_command` - (list) - Used only if Image deployment. List of values with which to override CMD entry in the image.
-- `image_config_entry_point` - (list) - Used only if Image deployment. List of values with which to override ENTRYPOINT entry in the image.
-- `image_config_working_directory` - (string) - Used only if Image deployment. Value with which to override WORKDIR entry in the image.
 - `security_group_ids` - (list) - The VPC security groups assigned to the Lambda.
 - `subnet_ids` - (list) - The VPC subnets in which the Lambda runs.
 - `timeout` (number) - The maximum time in seconds that the Lambda can run for.
 - `reserved_concurrent_executions` (number) - The amount of reserved concurrent executions for this lambda function.
 - `tags` (map) - A mapping of tags to assign to this lambda function.
 - `datadog_log_subscription_arn` - (string) - Log subscription arn for shipping logs to datadog.
-- `layers` - (list) - Used only if Zip deployment. ARNs of the layers to attach to the lambda function in order.
 
-> NOTE 1: if both security_group_ids and subnet_ids are empty then the Lambda will not have access to resources within a VPC.
+### Zip deployment variables
+- `runtime` - (string) - **REQUIRED** - The runtime environment for the Lambda function you are uploading.
+- `handler` - (map) - **REQUIRED** - The function within your code that Lambda calls to begin execution.
+- `s3_bucket` - (string) - **REQUIRED** - The name of the bucket containing your uploaded Lambda deployment package.
+- `s3_key` - (string) - **REQUIRED** - The s3 key for your Lambda deployment package.
+- `layers` - (list) - ARNs of the layers to attach to the lambda function in order.
 
-> NOTE 2: if image_uri is set then ECR Image will be deployed regardless of what Zip deployment properties are set to.
+### Image deployment variables
+- `image_uri` - (string) - **REQUIRED** - Uri to the image in ECR repo.
+- `image_config_command` - (list) - List of values with which to override CMD entry in the image.
+- `image_config_entry_point` - (list) - List of values with which to override ENTRYPOINT entry in the image.
+- `image_config_working_directory` - (string) - Value with which to override WORKDIR entry in the image.
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,22 +7,29 @@ This module will deploy a Lambda function.
 ## Module Input Variables
 
 - `function_name` - (string) - **REQUIRED** - The name of the Lambda function.
-- `handler` - (map) - **REQUIRED** - The function within your code that Lambda calls to begin execution.
-- `lambda_env` - (map) - Environment parameters passed to the Lambda function
+- `handler` - (map) - **REQUIRED (Zip deployment)** - The function within your code that Lambda calls to begin execution.
+- `lambda_env` - (map) - Environment parameters passed to the Lambda function.
 - `lambda_role_policy` (string) - The Lambda IAM Role Policy.
-- `log_subscription_filter` - (string) - Subscription filter to filter logs sent to datadog
-- `memory_size` (number) - Amount of memory in MB your Lambda Function can use at runtime
-- `runtime` - (string) - **REQUIRED** The runtime environment for the Lambda function you are uploading.
-- `s3_bucket` - (string) - **REQUIRED** - The name of the bucket containing your uploaded Lambda deployment package.
-- `s3_key` - (string) - **REQUIRED** - The s3 key for your Lambda deployment package.
+- `log_subscription_filter` - (string) - Subscription filter to filter logs sent to datadog.
+- `memory_size` (number) - Amount of memory in MB your Lambda Function can use at runtime.
+- `runtime` - (string) - **REQUIRED (Zip deployment)** - The runtime environment for the Lambda function you are uploading.
+- `s3_bucket` - (string) - **REQUIRED  (Zip deployment)** - The name of the bucket containing your uploaded Lambda deployment package.
+- `s3_key` - (string) - **REQUIRED (Zip deployment)** - The s3 key for your Lambda deployment package.
+- `image_uri` - (string) - **REQUIRED (Image deployment)** - Uri to the image in ECR repo.
+- `image_config_command` - (list) - Used only if Image deployment. List of values with which to override CMD entry in the image.
+- `image_config_entry_point` - (list) - Used only if Image deployment. List of values with which to override ENTRYPOINT entry in the image.
+- `image_config_working_directory` - (string) - Used only if Image deployment. Value with which to override WORKDIR entry in the image.
 - `security_group_ids` - (list) - The VPC security groups assigned to the Lambda.
 - `subnet_ids` - (list) - The VPC subnets in which the Lambda runs.
-- `timeout` (number) - The maximum time in seconds that the Lambda can run for
+- `timeout` (number) - The maximum time in seconds that the Lambda can run for.
 - `reserved_concurrent_executions` (number) - The amount of reserved concurrent executions for this lambda function.
 - `tags` (map) - A mapping of tags to assign to this lambda function.
-- `datadog_log_subscription_arn` - (string) - Log subscription arn for shipping logs to datadog
+- `datadog_log_subscription_arn` - (string) - Log subscription arn for shipping logs to datadog.
+- `layers` - (list) - Used only if Zip deployment. ARNs of the layers to attach to the lambda function in order.
 
-> NOTE: if both security_group_ids and subnet_ids are empty then the Lambda will not have access to resources within a VPC.
+> NOTE 1: if both security_group_ids and subnet_ids are empty then the Lambda will not have access to resources within a VPC.
+
+> NOTE 2: if image_uri is set then ECR Image will be deployed regardless of what Zip deployment properties are set to.
 
 ## Usage
 

--- a/main.tf
+++ b/main.tf
@@ -3,19 +3,28 @@ terraform {
 }
 
 resource "aws_lambda_function" "lambda_function" {
-  image_uri                      = var.image_uri != "" ? var.image_uri : null
-  s3_bucket                      = var.s3_bucket != "" ? var.s3_bucket : null
-  s3_key                         = var.s3_key != "" ? var.s3_key : null
-  function_name                  = var.function_name
-  role                           = aws_iam_role.iam_for_lambda.arn
-  handler                        = var.handler
-  runtime                        = var.runtime
-  timeout                        = var.timeout
-  memory_size                    = var.memory_size
-  reserved_concurrent_executions = var.reserved_concurrent_executions
-  tags                           = var.tags
-  package_type                   = var.image_uri != "" ? "Image" : "Zip"
-  layers                         = var.layers
+  image_uri                       = var.image_uri != "" ? var.image_uri : null
+  s3_bucket                       = var.s3_bucket
+  s3_key                          = var.s3_key
+  function_name                   = var.function_name
+  role                            = aws_iam_role.iam_for_lambda.arn
+  handler                         = var.handler
+  runtime                         = var.runtime
+  timeout                         = var.timeout
+  memory_size                     = var.memory_size
+  reserved_concurrent_executions  = var.reserved_concurrent_executions
+  tags                            = var.tags
+  package_type                    = var.image_uri != "" ? "Image" : "Zip"
+  layers                          = var.layers
+
+  dynamic "image_config" {
+    for_each = var.image_uri != "" ? [1] : []
+    content  {
+        command = var.image_config_command
+        entry_point = var.image_config_entry_point
+        working_directory = var.image_config_working_directory
+    }
+  }
 
   vpc_config {
     subnet_ids         = var.subnet_ids

--- a/test/files/create_lambda_container.json
+++ b/test/files/create_lambda_container.json
@@ -1,6 +1,5 @@
 {
-    "resource_changes": [
-        {
+    "resource_changes": [{
             "address": "module.lambda.aws_cloudwatch_log_group.lambda_loggroup",
             "module_address": "module.lambda",
             "mode": "managed",
@@ -8,9 +7,7 @@
             "name": "lambda_loggroup",
             "provider_name": "aws",
             "change": {
-                "actions": [
-                    "create"
-                ],
+                "actions": ["create"],
                 "before": null,
                 "after": {
                     "kms_key_id": null,
@@ -24,8 +21,7 @@
                     "id": true
                 }
             }
-        },
-        {
+        }, {
             "address": "module.lambda.aws_iam_role.iam_for_lambda",
             "module_address": "module.lambda",
             "mode": "managed",
@@ -33,9 +29,7 @@
             "name": "iam_for_lambda",
             "provider_name": "aws",
             "change": {
-                "actions": [
-                    "create"
-                ],
+                "actions": ["create"],
                 "before": null,
                 "after": {
                     "assume_role_policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"lambda.amazonaws.com\"\n      },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
@@ -57,8 +51,7 @@
                     "unique_id": true
                 }
             }
-        },
-        {
+        }, {
             "address": "module.lambda.aws_iam_role_policy.lambda_policy",
             "module_address": "module.lambda",
             "mode": "managed",
@@ -66,9 +59,7 @@
             "name": "lambda_policy",
             "provider_name": "aws",
             "change": {
-                "actions": [
-                    "create"
-                ],
+                "actions": ["create"],
                 "before": null,
                 "after": {
                     "name": "policy",
@@ -80,8 +71,7 @@
                     "role": true
                 }
             }
-        },
-        {
+        }, {
             "address": "module.lambda.aws_lambda_function.lambda_function",
             "module_address": "module.lambda",
             "mode": "managed",
@@ -89,40 +79,41 @@
             "name": "lambda_function",
             "provider_name": "aws",
             "change": {
-                "actions": [
-                    "create"
-                ],
+                "actions": ["create"],
                 "before": null,
                 "after": {
                     "code_signing_config_arn": null,
                     "dead_letter_config": [],
                     "description": null,
-                    "environment": [
-                        {
+                    "environment": [{
                             "variables": null
                         }
                     ],
                     "file_system_config": [],
                     "filename": null,
                     "function_name": "check_lambda_function",
-                    "handler": "unused",
-                    "image_config": [],
+                    "handler": null,
+                    "image_config": [{
+                            "command": ["some_cmd"],
+                            "entry_point": ["some_entrypoint"],
+                            "working_directory": null
+                        }
+                    ],
                     "image_uri": "image",
                     "kms_key_arn": null,
-                    "layers": [],
+                    "layers": null,
                     "memory_size": 128,
                     "package_type": "Image",
                     "publish": false,
                     "reserved_concurrent_executions": -1,
-                    "runtime": "provided",
+                    "runtime": null,
                     "s3_bucket": null,
                     "s3_key": null,
                     "s3_object_version": null,
                     "tags": null,
                     "timeout": 3,
                     "timeouts": null,
-                    "vpc_config": [
-                        {
+                    "vpc_config": [{
                             "security_group_ids": null,
                             "subnet_ids": null
                         }
@@ -131,15 +122,17 @@
                 "after_unknown": {
                     "arn": true,
                     "dead_letter_config": [],
-                    "environment": [
-                        {}
+                    "environment": [{}
                     ],
                     "file_system_config": [],
                     "id": true,
-                    "image_config": [],
+                    "image_config": [{
+                            "command": [false],
+                            "entry_point": [false]
+                        }
+                    ],
                     "invoke_arn": true,
                     "last_modified": true,
-                    "layers": [],
                     "qualified_arn": true,
                     "role": true,
                     "signing_job_arn": true,
@@ -148,8 +141,7 @@
                     "source_code_size": true,
                     "tracing_config": true,
                     "version": true,
-                    "vpc_config": [
-                        {
+                    "vpc_config": [{
                             "vpc_id": true
                         }
                     ]

--- a/test/infra_container/main.tf
+++ b/test/infra_container/main.tf
@@ -18,9 +18,9 @@ provider "aws" {
 module "lambda" {
   source                         = "../.."
   image_uri                      = "image"
+  image_config_command           = ["some_cmd"]
+  image_config_entry_point       = ["some_entrypoint"]
   function_name                  = "check_lambda_function"
-  handler                        = "unused"
-  runtime                        = "provided"
 }
 
 output "lambda_function_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,28 +1,54 @@
 variable "image_uri" {
+  type        = string
   description = "Optional ECR image (for image based lambda)"
   default     = ""
 }
 
+variable "image_config_command" {
+  type        = list(string)
+  description = "Optional override of image's CMD"
+  default     = null
+}
+
+variable "image_config_entry_point" {
+  type        = list(string)
+  description = "Optional override of image's ENTRYPOINT"
+  default     = null
+}
+
+variable "image_config_working_directory" {
+  type        = string
+  description = "Optional override of image's WORKDIR"
+  default     = null
+}
+
 variable "s3_bucket" {
+  type        = string
   description = "The name of the bucket containing your uploaded Lambda deployment package."
-  default     = ""
+  default     = null
 }
 
 variable "s3_key" {
+  type        = string
   description = "The s3 key for your Lambda deployment package."
-  default     = ""
+  default     = null
 }
 
 variable "function_name" {
+  type        = string
   description = "The name of the Lambda function."
 }
 
 variable "handler" {
+  type        = string
   description = "The function within your code that Lambda calls to begin execution."
+  default     = null
 }
 
 variable "runtime" {
+  type        = string
   description = "The runtime environment for the Lambda function you are uploading."
+  default     = null
 }
 
 variable "subnet_ids" {
@@ -38,11 +64,13 @@ variable "security_group_ids" {
 }
 
 variable "datadog_log_subscription_arn" {
+  type        = string
   description = "Log subscription arn for shipping logs to datadog"
   default     = ""
 }
 
 variable "lambda_role_policy" {
+  type        = string
   description = "The Lambda IAM Role Policy."
   default     = <<END
 {
@@ -63,11 +91,13 @@ END
 }
 
 variable "timeout" {
+  type        = number
   description = "The maximum time in seconds that the Lambda can run for."
   default     = 3
 }
 
 variable "memory_size" {
+  type        = number
   description = "Amount of memory in MB your Lambda Function can use at runtime."
   default     = 128
 }
@@ -79,11 +109,13 @@ variable "lambda_env" {
 }
 
 variable "log_subscription_filter" {
+  type        = string
   description = "Subscription filter to filter logs sent to datadog"
   default     = ""
 }
 
 variable "reserved_concurrent_executions" {
+  type        = number
   description = "Reserved concurrent executions for this Lambda"
   default     = -1
 }
@@ -97,5 +129,5 @@ variable "tags" {
 variable "layers" {
   type        = list(string)
   description = "ARNs of the layers to attach to the lambda function in order"
-  default     = []
+  default     = null
 }


### PR DESCRIPTION
Hi all, changes in here unify Zip / Image lambda deployments in single TF module. Have added missing image related parameters and have also cleaned up some defaults for Zip....pls RE-CHECK!!!. README updated + tests pass.
If merged, you can deprecate https://registry.terraform.io/modules/mergermarket/image-lambda/acuris